### PR TITLE
I've added distutisl setup to your package.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.settings/*
+.pydevproject

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .settings/*
 .pydevproject
+dist/*
+build/*
+RELEASE-VERSION
+MANIFEST

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+recursive-include form_designer/locale *.mo
+graft form_designer/media
+graft form_designer/templates
+include LICENSE
+include README.md
+include RELEASE-VERSION

--- a/form_designer/template_field.py
+++ b/form_designer/template_field.py
@@ -11,7 +11,7 @@ class TemplateFormField(forms.CharField):
         from django.template import Template, TemplateSyntaxError
         try:
             Template(value)
-        except TemplateSyntaxError as error:
+        except TemplateSyntaxError, error:
             raise forms.ValidationError(error)
         return value
 

--- a/form_designer/templates/html/formdefinition/forms/default.html
+++ b/form_designer/templates/html/formdefinition/forms/default.html
@@ -6,7 +6,7 @@
 </ul>
 {% endif %}
 <form name="{{ form_definition.name }}" action="{{ form_definition.action }}" method="{{ form_definition.method }}">
-
+{% csrf_token %}
     {% for field in form %}
     {% if not field.is_hidden %}
     {{ field.errors }}

--- a/get_git_version.py
+++ b/get_git_version.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+# Author: Douglas Creager <dcreager@dcreager.net>
+# This file is placed into the public domain.
+
+# Calculates the current version number. If possible, this is the
+# output of “git describe”, modified to conform to the versioning
+# scheme that setuptools uses. If “git describe” returns an error
+# (most likely because we're in an unpacked copy of a release tarball,
+# rather than in a git working copy), then we fall back on reading the
+# contents of the RELEASE-VERSION file.
+#
+# To use this script, simply import it your setup.py file, and use the
+# results of get_git_version() as your package version:
+#
+# from version import *
+#
+# setup(
+# version=get_git_version(),
+# .
+# .
+# .
+# )
+#
+# This will automatically update the RELEASE-VERSION file, if
+# necessary. Note that the RELEASE-VERSION file should *not* be
+# checked into git; please add it to your top-level .gitignore file.
+#
+# You'll probably want to distribute the RELEASE-VERSION file in your
+# sdist tarballs; to do this, just create a MANIFEST.in file that
+# contains the following line:
+#
+# include RELEASE-VERSION
+
+__all__ = ("get_git_version")
+
+from subprocess import Popen, PIPE
+
+
+def call_git_describe(abbrev=4):
+    try:
+        p = Popen(['git', 'describe', '--abbrev=%d' % abbrev],
+                  stdout=PIPE, stderr=PIPE)
+        p.stderr.close()
+        line = p.stdout.readlines()[0]
+        return line.strip()
+
+    except:
+        return None
+
+
+def read_release_version():
+    try:
+        f = open("RELEASE-VERSION", "r")
+
+        try:
+            version = f.readlines()[0]
+            return version.strip()
+
+        finally:
+            f.close()
+
+    except:
+        return None
+
+
+def write_release_version(version):
+    f = open("RELEASE-VERSION", "w")
+    f.write("%s\n" % version)
+    f.close()
+
+
+def get_git_version(abbrev=4):
+    # Read in the version that's currently in RELEASE-VERSION.
+
+    release_version = read_release_version()
+
+    # First try to get the current version using “git describe”.
+
+    version = call_git_describe(abbrev)
+
+    # If that doesn't work, fall back on the value that's in
+    # RELEASE-VERSION.
+
+    if version is None:
+        version = release_version
+
+    # If we still don't have anything, that's an error.
+
+    if version is None:
+        raise ValueError("Cannot find the version number!")
+
+    # If the current version is different from what's in the
+    # RELEASE-VERSION file, update the file to be current.
+
+    if version != release_version:
+        write_release_version(version)
+
+    # Finally, return the current version.
+
+    return version
+
+
+if __name__ == "__main__":
+    print get_git_version()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,128 @@
+import os
+from distutils.core import setup
+from subprocess import Popen, PIPE
+
+def read(fname):
+    """Utility function to read the README file.
+    
+    Used for the long_description.  It's nice, because now
+    1) we have a top level README file and
+    2) it's easier to type in the README file than to put a raw string in below ...
+    """
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+def call_git_describe(abbrev=4):
+    try:
+        p = Popen(['git', 'describe', '--abbrev=%d' % abbrev],
+                  stdout=PIPE, stderr=PIPE)
+        p.stderr.close()
+        line = p.stdout.readlines()[0]
+        return line.strip()
+
+    except:
+        return None
+
+
+def read_release_version():
+    try:
+        f = open("RELEASE-VERSION", "r")
+
+        try:
+            version = f.readlines()[0]
+            return version.strip()
+
+        finally:
+            f.close()
+
+    except:
+        return None
+
+
+def write_release_version(version):
+    f = open("RELEASE-VERSION", "w")
+    f.write("%s\n" % version)
+    f.close()
+
+
+def get_git_version(abbrev=4):
+    """
+    Author: Douglas Creager <dcreager@dcreager.net>
+    This file is placed into the public domain.
+    
+    Calculates the current version number. If possible, this is the
+    output of 'git describe', modified to conform to the versioning
+    scheme that setuptools uses. If 'git describe' returns an error
+    (most likely because we're in an unpacked copy of a release tarball,
+    rather than in a git working copy), then we fall back on reading the
+    contents of the RELEASE-VERSION file.
+        
+    This function will automatically update the RELEASE-VERSION file, if
+    necessary. Note that the RELEASE-VERSION file should *not* be
+    checked into git; please add it to your top-level .gitignore file.
+    
+    You'll probably want to distribute the RELEASE-VERSION file in your
+    sdist tarballs; to do this, just create a MANIFEST.in file that
+    contains the following line:
+    
+    include RELEASE-VERSION
+    
+    """
+    # Read in the version that's currently in RELEASE-VERSION.
+
+    release_version = read_release_version()
+
+    # First try to get the current version using 'git describe'.
+
+    version = call_git_describe(abbrev)
+
+    # If that doesn't work, fall back on the value that's in
+    # RELEASE-VERSION.
+
+    if version is None:
+        version = release_version
+
+    # If we still don't have anything, that's an error.
+
+    if version is None:
+        raise ValueError("Cannot find the version number!")
+
+    # If the current version is different from what's in the
+    # RELEASE-VERSION file, update the file to be current.
+
+    if version != release_version:
+        write_release_version(version)
+
+    # Finally, return the current version.
+
+    return version
+
+version = get_git_version()
+
+if "a" in version:
+    devstatus = "Development Status :: 3 - Alpha"
+elif "b" in version:
+    devstatus = "Development Status :: 4 - Beta"
+else:
+    devstatus = "Development Status :: 5 - Production/Stable"
+
+
+
+
+setup(
+    name = "django-form-designer",
+    version = version,
+    author = "Samuel Luescher",
+    url = "http://github.com/philomat/django-form-designer",
+    license = "BSD",
+    description = ("A Django app for building many kinds of forms visually, without any programming knowledge."),
+    packages = ['form_designer', 'form_designer.templatetags'],
+    platforms = ['OS Independent'],
+    long_description = read('README.md'),
+    classifiers = [
+        devstatus,
+        "Programming Language :: Python",
+        "Framework :: Django",
+        "License :: OSI Approved :: BSD License",
+        "Environment :: Web Environment",
+    ],
+)


### PR DESCRIPTION
I've done this in order to easy install and update through pip. I haven't registered it with pypi though, as I want pypi to point to your tree whenever you feel ready to implement distutils.

Nothing special going on in setup.py, except for the little trick that extracts version number from the git tag in the form of "tagname-extracommits-commitid". That's why I had to have an initial tag. I choose 0.1a, indicating alpha stage, but surely you could up that.

What's your view on this?

Thank for this great app btw.

Dries.
