### PR TITLE
Fixed broken dependency on Django-CMS bundled jQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ This document assumes that you are familiar with Python and Django.
 6. Add the form\_designer URLs to your URL conf. For instance, in order to make a form named `example-form` available under `http://domain.com/forms/example-form`, add the following line to `urls.py`. Note: __If you are using the form\_designer plugin for Django CMS, this step is not necessary__:
 
         urlpatterns = patterns('',
-            (r'^forms/', include('form\_designer.urls')),
+            (r'^forms/', include('form_designer.urls')),
             ...
         )
 
 7. Add the form\_designer admin URLs to your URL conf if you want to use CSV export. Add the following line to `urls.py` _before_ the admin URLs:
 
         urlpatterns = patterns('',
-            (r'^admin/form\_designer/', include('form\_designer.admin\_urls')),
+            (r'^admin/form_designer/', include('form_designer.admin_urls')),
             ...
             (r'^admin/', include(admin.site.urls)),
         )

--- a/README.md
+++ b/README.md
@@ -41,17 +41,17 @@ This document assumes that you are familiar with Python and Django.
 
         $ manage.py syncdb
 
-6. Add the form_designer URLs to your URL conf. For instance, in order to make a form named `example-form` available under `http://domain.com/forms/example-form`, add the following line to `urls.py`. Note: __If you are using the form_designer plugin for Django CMS, this step is not necessary__:
+6. Add the form\_designer URLs to your URL conf. For instance, in order to make a form named `example-form` available under `http://domain.com/forms/example-form`, add the following line to `urls.py`. Note: __If you are using the form\_designer plugin for Django CMS, this step is not necessary__:
 
         urlpatterns = patterns('',
-            (r'^forms/', include('form_designer.urls')),
+            (r'^forms/', include('form\_designer.urls')),
             ...
         )
 
-7. Add the form_designer admin URLs to your URL conf if you want to use CSV export. Add the following line to `urls.py` _before_ the admin URLs:
+7. Add the form\_designer admin URLs to your URL conf if you want to use CSV export. Add the following line to `urls.py` _before_ the admin URLs:
 
         urlpatterns = patterns('',
-            (r'^admin/form_designer/', include('form_designer.admin_urls')),
+            (r'^admin/form\_designer/', include('form\_designer.admin\_urls')),
             ...
             (r'^admin/', include(admin.site.urls)),
         )
@@ -60,6 +60,6 @@ Optional requirements
 ---------------------
 
 * form_designer supports [django-notify](http://code.google.com/p/django-notify/) for error messages and success notifications. If it is installed in your project, it will be used automatically, and you need to output the `{{ notifications }}` variable in your templates.
-* The form_designer admin interface requires jQuery and the jQuery UI Sortable plugin to make building forms a lot more user-friendly. The two Javascript files are bundled with form_designer. Optionally, if Django CMS is installed, the files bundled with that app will be used. If you want to use you own jquery.js instead because you're already including it anyway, define JQUERY_JS in your settings file. For instance:
+* The form\_designer admin interface requires jQuery and the jQuery UI Sortable plugin to make building forms a lot more user-friendly. The two Javascript files are bundled with form_designer. If you want to use you own jquery.js instead because you're already including it anyway, define JQUERY\_JS in your settings file. For instance:
 
         JQUERY_JS = 'jquery/jquery-latest.js'

--- a/form_designer/forms.py
+++ b/form_designer/forms.py
@@ -55,21 +55,19 @@ class FormDefinitionForm(forms.ModelForm):
 
     def _media(self):
         js = []
-        if hasattr(django_settings, 'CMS_MEDIA_URL'):
-            # Use jQuery bundled with django_cms if installed
-            js.append(os.path.join(django_settings.CMS_MEDIA_URL, 'js/lib/jquery.js'))
-        elif hasattr(django_settings, 'JQUERY_URL'):
+        plugins = [
+            'js/jquery-ui.js',
+            'js/jquery-inline-positioning.js',
+            'js/jquery-inline-rename.js',
+            'js/jquery-inline-collapsible.js',
+            'js/jquery-inline-fieldset-collapsible.js',
+            'js/jquery-inline-prepopulate-label.js',
+        ]
+        if hasattr(django_settings, 'JQUERY_URL'):
             js.append(django_settings.JQUERY_URL)
         else:
-            js.append('%s%s' % (settings.STATIC_URL, 'js/jquery.js'))
+            plugins = ['js/jquery.js'] + plugins
         js.extend(
-            ['%s%s' % (settings.STATIC_URL, path) for path in (
-                'js/jquery-ui.js',
-                'js/jquery-inline-positioning.js',
-                'js/jquery-inline-rename.js',
-                'js/jquery-inline-collapsible.js',
-                'js/jquery-inline-fieldset-collapsible.js',
-                'js/jquery-inline-prepopulate-label.js',
-            )])
+            [os.path.join(settings.STATIC_URL, path) for path in plugins])
         return forms.Media(js=js)
     media = property(_media)

--- a/form_designer/settings.py
+++ b/form_designer/settings.py
@@ -1,8 +1,10 @@
+import os.path
+
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 from django.core.files.storage import get_storage_class
 
-STATIC_URL = getattr(settings, 'STATIC_URL', settings.MEDIA_URL) + '/form_designer/'
+STATIC_URL = os.path.join(getattr(settings, 'STATIC_URL', settings.MEDIA_URL), 'form_designer')
 
 FIELD_CLASSES = getattr(settings, 'FORM_DESIGNER_FIELD_CLASSES', (
     ('django.forms.CharField', _('Text')),


### PR DESCRIPTION
Django-CMS does not bundle jQuery any longer. I've updated the code to either expect the user to set JQUERY_URL, otherwise falls back to the jQuery bundled in django-form-designer.

Hat tip to @dustinfarris for identifying the bug.
