### PR TITLE
Make sure to get a storage dependent valid file name when handling uploaded files

### DIFF
--- a/form_designer/uploads.py
+++ b/form_designer/uploads.py
@@ -42,7 +42,8 @@ def handle_uploaded_files(form_definition, form):
             uploaded_file = form.cleaned_data.get(field.name, None)
             if uploaded_file is None:
                 continue
-            root, ext = os.path.splitext(uploaded_file.name)
+            valid_file_name = storage.get_valid_name(uploaded_file.name)
+            root, ext = os.path.splitext(valid_file_name)
             filename = storage.get_available_name(
                 os.path.join(app_settings.FILE_STORAGE_DIR, 
                 form_definition.name, 


### PR DESCRIPTION
Django doesn't play well with uploaded files containing non-ascii char.

On way to get around this issue is creating a custom storage backend.

``` python
import unicodedata

from django.core.files.storage import FileSystemStorage

class ASCIIFileSystemStorage(FileSystemStorage):
    """Convert unicode characters in name to ASCII characters."""
    def get_valid_name(self, name):
        name = unicodedata.normalize('NFKD', name).encode('ascii', 'ignore')
        return super(ASCIIFileSystemStorage, self).get_valid_name(name)
```

And defining it as the default storage backend in you settings.

``` python
DEFAULT_FILE_STORAGE = 'common.storage.ASCIIFileSystemStorage'
```

However django-form-designer's upload mechanism doesn't honor the storage dependent valid file name scheme. The attached pull request fixes that.
