### PR TITLE
Minor fix: avoid distutils complaining about README.md

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include AUTHORS
-include README.md
+include README.rst
 include LICENSE
 recursive-include form_designer/templates *.html *.txt
 recursive-include form_designer/static *.js


### PR DESCRIPTION
The README uses .rst file extension but the MANIFEST.in file still referenced the old .md extension.
