### PR TITLE
Bumping the max_length for the field_class to allow adding longer class ...

### DIFF
--- a/form_designer/models.py
+++ b/form_designer/models.py
@@ -181,7 +181,7 @@ class FormDefinition(models.Model):
 class FormDefinitionField(models.Model):
 
     form_definition = models.ForeignKey(FormDefinition)
-    field_class = models.CharField(_('field class'), choices=settings.FIELD_CLASSES, max_length=32)
+    field_class = models.CharField(_('field class'), choices=settings.FIELD_CLASSES, max_length=100)
     position = models.IntegerField(_('position'), blank=True, null=True)
 
     name = models.SlugField(_('name'), max_length=255)


### PR DESCRIPTION
I ran into trouble when trying to add a phone number field form with a class name of "phonenumber_field.formfields.PhoneNumberField" (which is longer than the current 32 char max) to the FIELD_CLASSES used in the combo box for adding a new form field.
