### PR TITLE
update for django 1.6.1

### DIFF
--- a/form_designer/admin.py
+++ b/form_designer/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.utils.translation import ugettext_lazy as _, ugettext
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from django.contrib.admin.views.main import ChangeList
 from django.http import Http404
 

--- a/form_designer/urls.py
+++ b/form_designer/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns('',
     url(r'^(?P<object_name>[-\w]+)/$', 'form_designer.views.detail', name='form_designer_detail'),


### PR DESCRIPTION
For the most part the currnet code base will work with django 1.6.1,  there are just a few pathing problems that needed to be resolved.  I have applied these change to a project of mine and it works the same as for django 1.6.1 as it did for django 1.5.4.  So i recommend that a new version be made to work with django 1.6.1
