### PR TITLE
Update cms_plugins.py

### DIFF
--- a/form_designer/contrib/cms_plugins/form_designer_form/cms_plugins.py
+++ b/form_designer/contrib/cms_plugins/form_designer_form/cms_plugins.py
@@ -13,6 +13,7 @@ class FormDesignerPlugin(CMSPluginBase):
     module = _('Form Designer')
     name = _('Form')
     admin_preview = False
+    render_template = ""
 
     def render(self, context, instance, placeholder):
         if instance.form_definition.form_template_name:

--- a/form_designer/contrib/cms_plugins/form_designer_form/cms_plugins.py
+++ b/form_designer/contrib/cms_plugins/form_designer_form/cms_plugins.py
@@ -13,7 +13,7 @@ class FormDesignerPlugin(CMSPluginBase):
     module = _('Form Designer')
     name = _('Form')
     admin_preview = False
-    render_template = ""
+    render_template = False
 
     def render(self, context, instance, placeholder):
         if instance.form_definition.form_template_name:


### PR DESCRIPTION
Added render_template shim to class definition - fixes ImproperlyConfigured Exception in Django-CMS 3.0RC1

 "CMS Plugins must define a render template or set render_plugin=False: <class 'form_designer.contrib.cms_plugins.form_designer_form.cms_plugins.FormDesignerPlugin'>"
