### PR TITLE
fixes django cms 3 compatibility

### DIFF
--- a/form_designer/contrib/cms_plugins/form_designer_form/cms_plugins.py
+++ b/form_designer/contrib/cms_plugins/form_designer_form/cms_plugins.py
@@ -14,6 +14,7 @@ class FormDesignerPlugin(CMSPluginBase):
     name = _('Form')
     admin_preview = False
     render_template = False
+    cache = False
 
     def render(self, context, instance, placeholder):
         if instance.form_definition.form_template_name:

--- a/form_designer/contrib/cms_plugins/form_designer_form/cms_plugins.py
+++ b/form_designer/contrib/cms_plugins/form_designer_form/cms_plugins.py
@@ -23,7 +23,7 @@ class FormDesignerPlugin(CMSPluginBase):
             self.render_template = settings.DEFAULT_FORM_TEMPLATE
 
         # Redirection does not work with CMS plugin, hence disable:
-        return process_form(context['request'], instance.form_definition, context, disable_redirection=True)
+        return process_form(context['request'], instance.form_definition, context, disable_redirection=True, push_messages=False)
 
 
 plugin_pool.register_plugin(FormDesignerPlugin)

--- a/form_designer/views.py
+++ b/form_designer/views.py
@@ -18,7 +18,7 @@ from form_designer.signals import (designedform_submit, designedform_success,
                                 designedform_error, designedform_render)
 
 
-def process_form(request, form_definition, extra_context={}, disable_redirection=False):
+def process_form(request, form_definition, extra_context={}, disable_redirection=False, push_messages=True):
     context = extra_context
     success_message = form_definition.success_message or _('Thank you, the data was submitted successfully.')
     error_message = form_definition.error_message or _('The data could not be submitted, please try again.')
@@ -41,7 +41,8 @@ def process_form(request, form_definition, extra_context={}, disable_redirection
             files = handle_uploaded_files(form_definition, form)
 
             # Successful submission
-            messages.success(request, success_message)
+            if push_messages:
+                messages.success(request, success_message)
             form_success = True
 
             designedform_success.send(sender=process_form, context=context,
@@ -59,7 +60,8 @@ def process_form(request, form_definition, extra_context={}, disable_redirection
             form_error = True
             designedform_error.send(sender=process_form, context=context,
                 form_definition=form_definition, request=request)
-            messages.error(request, error_message)
+            if push_messages:
+                messages.error(request, error_message)
     else:
         if form_definition.allow_get_initial:
             form = DesignedForm(form_definition, initial_data=request.GET)


### PR DESCRIPTION
This PR adds cache = False to the plugin, so that it works again with django cms 3, see issue #83. Another change is that it removes the pushing of contrib messages in the context of a plugin. This make no sense in a plugin (no redirect is possible as plugin), without this change the message shows on the second request, on another page.
