### PR TITLE
small modifications to use success and error messages in cms_plugin

### DIFF
--- a/form_designer/contrib/cms_plugins/form_designer_form/cms_plugins.py
+++ b/form_designer/contrib/cms_plugins/form_designer_form/cms_plugins.py
@@ -14,6 +14,7 @@ class FormDesignerPlugin(CMSPluginBase):
     name = _('Form')
     admin_preview = False
     render_template = False
+    cache = False  # new with New in version 3.0. see http://django-cms.readthedocs.org/en/latest/advanced/caching.html
 
     def render(self, context, instance, placeholder):
         if instance.form_definition.form_template_name:

--- a/form_designer/settings.py
+++ b/form_designer/settings.py
@@ -41,6 +41,7 @@ EXPORTER_CLASSES = getattr(settings, 'FORM_DESIGNER_EXPORTER_CLASSES', (
 FORM_TEMPLATES = getattr(settings, 'FORM_DESIGNER_FORM_TEMPLATES', (
     ('', _('Default')),
     ('html/formdefinition/forms/as_p.html', _('as paragraphs')),
+    ('html/formdefinition/forms/as_p_cms.html', _('as paragraphs for cms')),
     ('html/formdefinition/forms/as_table.html', _('as table')),
     ('html/formdefinition/forms/as_table_h.html', _('as table (horizontal)')),
     ('html/formdefinition/forms/as_ul.html', _('as unordered list')),

--- a/form_designer/templates/html/formdefinition/forms/as_p_cms.html
+++ b/form_designer/templates/html/formdefinition/forms/as_p_cms.html
@@ -1,10 +1,10 @@
 {% load friendly %}
 
 {% if form_success %}
-        {{ form_success_message }}
+        {{ form_success_message | friendly }}
 {% else %}
         {% if form_error %}
-            {{ form_error_message }}
+            {{ form_error_message | friendly }}
         {% endif %}
     <form name="{{ form_definition.name }}" action="{{ form_definition.action }}" method="{{ form_definition.method }}" enctype="multipart/form-data">
         {% for entry in logs %}

--- a/form_designer/templates/html/formdefinition/forms/as_p_cms.html
+++ b/form_designer/templates/html/formdefinition/forms/as_p_cms.html
@@ -1,0 +1,35 @@
+{% load friendly %}
+
+{% if form_success %}
+        {{ form_success_message }}
+{% else %}
+        {% if form_error %}
+            {{ form_error_message }}
+        {% endif %}
+    <form name="{{ form_definition.name }}" action="{{ form_definition.action }}" method="{{ form_definition.method }}" enctype="multipart/form-data">
+        {% for entry in logs %}
+            {% for field in entry.data %}
+            <p>
+                <label for="">{{ field.label }}</label>
+                {{ field.value|friendly }}
+            </p>
+            {% endfor %}
+        {% endfor %}
+        {% for field in form %}
+            {% if not field.is_hidden %}
+                {{ field.errors }}
+                <p class="field {% if field.errors %}errors{% endif %}{% if field.field.required %}{% if field.errors %} {% endif %}required{% endif %}">
+                    <label for="{{ field.auto_id }}">{{ field.label }}</label>
+                    {{ field }}
+                </p>
+            {% endif %}
+        {% endfor %}
+        <p class="buttons">
+        {% include "html/formdefinition/forms/includes/submit.html" %}
+        </p>
+        {% for field in form.hidden_fields %}
+            {{ field }}
+        {% endfor %}
+        {% csrf_token %}
+    </form>
+{% endif %}

--- a/form_designer/templates/html/formdefinition/forms/as_p_cms.html
+++ b/form_designer/templates/html/formdefinition/forms/as_p_cms.html
@@ -1,10 +1,10 @@
 {% load friendly %}
 
 {% if form_success %}
-        {{ form_success_message | friendly }}
+        {{ form_success_message | safe }}
 {% else %}
         {% if form_error %}
-            {{ form_error_message | friendly }}
+            {{ form_error_message | safe }}
         {% endif %}
     <form name="{{ form_definition.name }}" action="{{ form_definition.action }}" method="{{ form_definition.method }}" enctype="multipart/form-data">
         {% for entry in logs %}

--- a/form_designer/views.py
+++ b/form_designer/views.py
@@ -71,6 +71,8 @@ def process_form(request, form_definition, extra_context={}, disable_redirection
     context.update({
         'form_error': form_error,
         'form_success': form_success,
+        'form_success_message': success_message,
+        'form_error_message': error_message,
         'form': form,
         'form_definition': form_definition
     })


### PR DESCRIPTION
Disabled the cache for the the cms_plugin (needs Django CMS >= 3.0), added a new default template for cms and extended views.py
