### PR TITLE
Update utils.py

### DIFF
--- a/form_designer/utils.py
+++ b/form_designer/utils.py
@@ -9,7 +9,7 @@ def get_class(import_path):
     module, classname = import_path[:dot], import_path[dot + 1:]
     try:
         mod = import_module(module)
-    except ImportError, e:
+    except ImportError as e:
         raise ImproperlyConfigured('Error importing module %s: "%s"' %
                                    (module, e))
     try:


### PR DESCRIPTION
The following syntax:

except ImportError, e:
was deprecated in Python 2.7 and removed in Python 3.x. Nowadays, you use the as keyword
