### PR TITLE
Update fields.py

### DIFF
--- a/form_designer/fields.py
+++ b/form_designer/fields.py
@@ -53,7 +53,7 @@ class TemplateFormField(forms.CharField):
         from django.template import Template, TemplateSyntaxError
         try:
             Template(value)
-        except TemplateSyntaxError, error:
+        except TemplateSyntaxError as error:
             raise ValidationError(error)
         return value
 


### PR DESCRIPTION
The following syntax:

except ImportError, e:
was deprecated in Python 2.7 and removed in Python 3.x. Nowadays, you use the as keyword
