### PR TITLE
Added missing migration 0010.

### DIFF
--- a/form_designer/migrations/0010_auto__chg_field_formdefinitionfield_field_class__chg_field_formvalue_v.py
+++ b/form_designer/migrations/0010_auto__chg_field_formdefinitionfield_field_class__chg_field_formvalue_v.py
@@ -1,0 +1,131 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'FormDefinitionField.field_class'
+        db.alter_column(u'form_designer_formdefinitionfield', 'field_class', self.gf('django.db.models.fields.CharField')(max_length=100))
+
+        # Changing field 'FormValue.value'
+        db.alter_column(u'form_designer_formvalue', 'value', self.gf('picklefield.fields.PickledObjectField')(null=True))
+
+    def backwards(self, orm):
+
+        # Changing field 'FormDefinitionField.field_class'
+        db.alter_column(u'form_designer_formdefinitionfield', 'field_class', self.gf('django.db.models.fields.CharField')(max_length=32))
+
+        # Changing field 'FormValue.value'
+        db.alter_column(u'form_designer_formvalue', 'value', self.gf('django.db.models.fields.TextField')(null=True))
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '75'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'form_designer.formdefinition': {
+            'Meta': {'object_name': 'FormDefinition'},
+            'action': ('django.db.models.fields.URLField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'allow_get_initial': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'body': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'display_logged': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'error_message': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'form_template_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'log_data': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'mail_from': ('form_designer.fields.TemplateCharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'mail_subject': ('form_designer.fields.TemplateCharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'mail_to': ('form_designer.fields.TemplateCharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'mail_uploaded_files': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'message_template': ('form_designer.fields.TemplateTextField', [], {'null': 'True', 'blank': 'True'}),
+            'method': ('django.db.models.fields.CharField', [], {'default': "'POST'", 'max_length': '10'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255'}),
+            'private_hash': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '40'}),
+            'public_hash': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '40'}),
+            'require_hash': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'save_uploaded_files': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'submit_label': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'success_clear': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'success_message': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'success_redirect': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'})
+        },
+        u'form_designer.formdefinitionfield': {
+            'Meta': {'ordering': "['position']", 'object_name': 'FormDefinitionField'},
+            'choice_labels': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'choice_model': ('form_designer.fields.ModelNameField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'choice_model_empty_label': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'choice_values': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'decimal_places': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'field_class': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'form_definition': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['form_designer.FormDefinition']"}),
+            'help_text': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'include_result': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'initial': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'max_digits': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'max_length': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'max_value': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'min_length': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'min_value': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'max_length': '255'}),
+            'position': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'regex': ('form_designer.fields.RegexpExpressionField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'required': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'widget': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255', 'null': 'True', 'blank': 'True'})
+        },
+        u'form_designer.formlog': {
+            'Meta': {'object_name': 'FormLog'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'form_definition': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'logs'", 'to': u"orm['form_designer.FormDefinition']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'form_designer.formvalue': {
+            'Meta': {'object_name': 'FormValue'},
+            'field_name': ('django.db.models.fields.SlugField', [], {'max_length': '255'}),
+            'form_log': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'values'", 'to': u"orm['form_designer.FormLog']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'value': ('picklefield.fields.PickledObjectField', [], {'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['form_designer']


### PR DESCRIPTION
Hello. The present pull request adds a missing migration which was not present in the repository at all.

That provoked databases to mismatch what is defined in app models. As an example, the `FormDefinitionField.field_class` model field is declared with a `max_length` of 100 chars, but in the database it was creating a `varchar(32)` column. That lead to DB exceptions when trying to add some custom extra form fields.
