### PR TITLE
Migrate setup.py from distutils -> setuptools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-*.pyc
+*.py[cod]
 .*
 dist
 MANIFEST
-
+*.egg-info

--- a/AUTHORS
+++ b/AUTHORS
@@ -27,3 +27,4 @@ Estuans (estuans)
 bloynd
 mrmachine (Tai Lee)
 Ben Waters (the-ben-waters)
+Peter Bittner (bittner)

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Django Form Designer
 ********************
 
-A Django admin app with a GUI to create complex forms without any programming skills; 
+A Django admin app with a GUI to create complex forms without any programming skills;
 complete with logging, validation, and redirects.
 
 **Key features**:
@@ -10,10 +10,10 @@ complete with logging, validation, and redirects.
 * Form data can be logged and CSV-exported, sent via e-mail, or forwarded to any web address
 * Integration with `Django CMS <http://www.django-cms.org>`_: Add forms to any page
 * Use drag & drop to change the position of your form fields
-* Fully collapsible admin interface for better overview over your form 
+* Fully collapsible admin interface for better overview over your form
 * Implements many form fields included with Django (TextField, EmailField, DateField etc)
-* Validation rules as supplied by Django are fully configurable (maximum length, regular 
-  expression etc) 
+* Validation rules as supplied by Django are fully configurable (maximum length, regular
+  expression etc)
 * Customizable messages and labels
 * Supports POST and GET forms
 * Signals on form render, submission, success, error.
@@ -26,9 +26,9 @@ This install guide assumes that you are familiar with Python and Django.
 
 - Install the module using pip::
 
-    $ pip install git+git://github.com/philomat/django-form-designer.git#egg=django-form-designer
+    $ pip install git+git://github.com/samluescher/django-form-designer.git#egg=django-form-designer
 
-  **or** download it from http://github.com/philomat/django-form-designer, and run the installation 
+  **or** download it from https://github.com/samluescher/django-form-designer, and run the installation
   script::
 
     $ python setup.py install
@@ -80,10 +80,10 @@ Basic setup
      public, this step is not necessary.
 
 
-Using Django Form Designer with Django CMS 
+Using Django Form Designer with Django CMS
 ==========================================
 
-- Add ``form_designer.contrib.cms_plugins.form_designer_form`` to your ``INSTALLED_APPS`` 
+- Add ``form_designer.contrib.cms_plugins.form_designer_form`` to your ``INSTALLED_APPS``
   setting::
 
         INSTALLED_APPS = (
@@ -95,7 +95,7 @@ Using Django Form Designer with Django CMS
 
     $ manage.py syncdb
 
-You can now add forms to pages created with Django CMS. 
+You can now add forms to pages created with Django CMS.
 
 
 Optional requirements

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 120
+max-complexity = 10
+exclude = build,dist,*/migrations,*.egg-info

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,34 @@
+#!/usr/bin/env python
 # encoding=utf8
-import os
-from distutils.core import setup
+from pip.req import parse_requirements
+from os.path import dirname, join
+from setuptools import setup
+
+
+def read_requirements():
+    filepath = join(dirname(__file__), 'requirements.txt')
+    generator = parse_requirements(filepath, session=False)
+    return [str(requirement.req) for requirement in generator]
+
 
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    return open(join(dirname(__file__), fname)).read()
 
 README = read('README.rst')
 
 setup(
-    name = "django-form-designer",
-    version = "0.8.0",
-    url = 'http://github.com/philomat/django-form-designer',
-    license = 'BSD',
-    description = "Design contact forms, search forms etc from the Django admin, without writing any code. Integrates with Django CMS.",
-    long_description = README,
+    name="django-form-designer",
+    version="0.8.0",
+    url='https://github.com/samluescher/django-form-designer',
+    license='BSD',
+    description="Design contact forms, search forms etc from the Django admin,"
+                " without writing any code. Integrates with Django CMS.",
+    long_description=README,
 
-    author = 'Samuel Luescher',
-    author_email = 'sam at luescher dot org',
-    packages = [
+    author='Samuel Luescher',
+    author_email='sam at luescher dot org',
+    install_requires=read_requirements(),
+    packages=[
         'form_designer',
         'form_designer.migrations',
         'form_designer.templatetags',
@@ -26,7 +37,7 @@ setup(
         'form_designer.contrib.cms_plugins',
         'form_designer.contrib.cms_plugins.form_designer_form',
     ],
-    package_data = {
+    package_data={
         'form_designer': [
             'static/form_designer/js/*.js',
             'templates/admin/form_designer/formlog/change_list.html',
@@ -37,7 +48,7 @@ setup(
             'locale/*/LC_MESSAGES/*',
         ],
     },
-    classifiers = [
+    classifiers=[
         'Development Status :: 4 - Beta',
         'Framework :: Django',
         'Intended Audience :: Developers',


### PR DESCRIPTION
- Migrate `setup.py` from distutils to setuptools
- Update repository URL, clean up some whitespace (editor setting)
- Add settings for `flake8` in `setup.cfg`

The adapted `setup.py` now:
1. allows `python setup.py develop` (install project w/ link 4 development)
2. allows to be run as `./setup.py` (shebang)
3. installs dependencies automatically from `requirements.txt`
